### PR TITLE
Fixes implicit declaration of function ngx_http_upstream_check_add_peer

### DIFF
--- a/ngx_http_upstream_fair_module.c
+++ b/ngx_http_upstream_fair_module.c
@@ -8,6 +8,9 @@
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_http.h>
+#if (NGX_HTTP_UPSTREAM_CHECK)
+#include "ngx_http_upstream_check_module.h"
+#endif
 
 typedef struct {
     ngx_uint_t                          nreq;


### PR DESCRIPTION
Fixes implicit declaration of function 'ngx_http_upstream_check_add_peer' when compiling with nginx_upstream_check_module